### PR TITLE
Renders only provided social media

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,7 +102,7 @@ export const App: React.FC = () => {
 
   function renderContent(data: any) {
     return Object.entries(data).map(([key, value]: any) => {
-      if (getImage(key)) {
+      if (getImage(key) && value) {
         return <SocialLink link={value} path={getImage(key)} username={key} />;
       }
       return null;


### PR DESCRIPTION
### What this PR solves
When viewing the user cards, all the social medias were listed for every user, however not social media was being provided and some were empty, therefore making an empty link that just refreshes the page and doesn't redirect to anywhere.

### How the PR solves it
Instead of rendering every social media directly, it will render only the social medias that don't have a falsy value such as undefined, null or empty, therefore preventing unusable links and only showing the provided links.

|before|after|
|---|---|
|![image](https://user-images.githubusercontent.com/42651514/235279542-de5a59f6-2d28-404c-b28f-aeab5df37f15.png)|![image](https://user-images.githubusercontent.com/42651514/235279471-59b3ac20-56e5-4913-9868-070ac301de97.png)|